### PR TITLE
Add supplier and purchase order prototype pages

### DIFF
--- a/ej4/prototipo/index.html
+++ b/ej4/prototipo/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tienda Tech - Inicio</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">Tienda Tech</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav">
+        <li class="nav-item"><a class="nav-link active" href="index.html">Inicio</a></li>
+        <li class="nav-item"><a class="nav-link" href="productos.html">Productos</a></li>
+        <li class="nav-item"><a class="nav-link" href="producto_nuevo.html">Nuevo Producto</a></li>
+        <li class="nav-item"><a class="nav-link" href="proveedores.html">Proveedores</a></li>
+        <li class="nav-item"><a class="nav-link" href="proveedor_nuevo.html">Nuevo Proveedor</a></li>
+        <li class="nav-item"><a class="nav-link" href="ordenes.html">Órdenes de Compra</a></li>
+        <li class="nav-item"><a class="nav-link" href="orden_nueva.html">Nueva Orden</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+
+<div class="container mt-4">
+  <div class="p-5 mb-4 bg-light rounded-3">
+    <div class="container-fluid py-5">
+      <h1 class="display-5 fw-bold">Bienvenido a Tienda Tech</h1>
+      <p class="col-md-8 fs-4">Utilice el sistema para administrar el stock de productos.</p>
+      <a class="btn btn-primary btn-lg" href="productos.html">Ver productos</a>
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/ej4/prototipo/orden_nueva.html
+++ b/ej4/prototipo/orden_nueva.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tienda Tech - Nueva Orden de Compra</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">Tienda Tech</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav">
+        <li class="nav-item"><a class="nav-link" href="index.html">Inicio</a></li>
+        <li class="nav-item"><a class="nav-link" href="productos.html">Productos</a></li>
+        <li class="nav-item"><a class="nav-link" href="producto_nuevo.html">Nuevo Producto</a></li>
+        <li class="nav-item"><a class="nav-link" href="proveedores.html">Proveedores</a></li>
+        <li class="nav-item"><a class="nav-link" href="proveedor_nuevo.html">Nuevo Proveedor</a></li>
+        <li class="nav-item"><a class="nav-link" href="ordenes.html">Órdenes de Compra</a></li>
+        <li class="nav-item"><a class="nav-link active" href="orden_nueva.html">Nueva Orden</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+
+<div class="container mt-4">
+  <h2>Nueva Orden de Compra</h2>
+  <form>
+    <div class="row mb-3">
+      <div class="col-md-4">
+        <label class="form-label">Nº Orden</label>
+        <input type="text" class="form-control" placeholder="1">
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">Fecha</label>
+        <input type="date" class="form-control">
+      </div>
+    </div>
+
+    <h5>Enviar a</h5>
+    <div class="row mb-3">
+      <div class="col-md-6">
+        <label class="form-label">Proveedor</label>
+        <input type="text" class="form-control" placeholder="La Real S.A.">
+      </div>
+      <div class="col-md-6">
+        <label class="form-label">Contacto</label>
+        <input type="text" class="form-control" placeholder="Juan">
+      </div>
+    </div>
+    <div class="row mb-3">
+      <div class="col-md-6">
+        <label class="form-label">Domicilio</label>
+        <input type="text" class="form-control" placeholder="Rioja 398 - Palo Bajo">
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Ciudad</label>
+        <input type="text" class="form-control" placeholder="La Real S.A.">
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Teléfono</label>
+        <input type="text" class="form-control" placeholder="333-5212">
+      </div>
+    </div>
+
+    <h5>Condiciones</h5>
+    <div class="row mb-3">
+      <div class="col-md-4">
+        <label class="form-label">Entrega</label>
+        <input type="text" class="form-control" placeholder="Envío a domicilio">
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">Plazo</label>
+        <input type="text" class="form-control" placeholder="15 días">
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">Pago</label>
+        <input type="text" class="form-control" placeholder="Transferencia bancaria">
+      </div>
+    </div>
+
+    <h5>Detalle</h5>
+    <table class="table table-bordered">
+      <thead>
+        <tr>
+          <th>Nº</th>
+          <th>Artículo</th>
+          <th>Cantidad</th>
+          <th>Precio Unitario</th>
+          <th>Precio Total</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>1</td>
+          <td><input type="text" class="form-control" placeholder="Cable de red"></td>
+          <td><input type="number" class="form-control" placeholder="12"></td>
+          <td><input type="number" class="form-control" placeholder="24.00"></td>
+          <td><input type="number" class="form-control" placeholder="24.00"></td>
+        </tr>
+        <tr>
+          <td>2</td>
+          <td><input type="text" class="form-control" placeholder="Extensión"></td>
+          <td><input type="number" class="form-control" placeholder="5"></td>
+          <td><input type="number" class="form-control" placeholder="3.00"></td>
+          <td><input type="number" class="form-control" placeholder="15.00"></td>
+        </tr>
+        <tr>
+          <td>3</td>
+          <td><input type="text" class="form-control" placeholder="Triple"></td>
+          <td><input type="number" class="form-control" placeholder="1"></td>
+          <td><input type="number" class="form-control" placeholder="9.00"></td>
+          <td><input type="number" class="form-control" placeholder="9.00"></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="row mb-3">
+      <div class="col-md-4 ms-auto">
+        <label class="form-label">IVA</label>
+        <input type="text" class="form-control" placeholder="21%">
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">Sub-total</label>
+        <input type="text" class="form-control" placeholder="$33.00">
+      </div>
+    </div>
+
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a class="btn btn-secondary" href="ordenes.html">Cancelar</a>
+  </form>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/ej4/prototipo/ordenes.html
+++ b/ej4/prototipo/ordenes.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tienda Tech - Órdenes de Compra</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">Tienda Tech</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav">
+        <li class="nav-item"><a class="nav-link" href="index.html">Inicio</a></li>
+        <li class="nav-item"><a class="nav-link" href="productos.html">Productos</a></li>
+        <li class="nav-item"><a class="nav-link" href="producto_nuevo.html">Nuevo Producto</a></li>
+        <li class="nav-item"><a class="nav-link" href="proveedores.html">Proveedores</a></li>
+        <li class="nav-item"><a class="nav-link" href="proveedor_nuevo.html">Nuevo Proveedor</a></li>
+        <li class="nav-item"><a class="nav-link active" href="ordenes.html">Órdenes de Compra</a></li>
+        <li class="nav-item"><a class="nav-link" href="orden_nueva.html">Nueva Orden</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+
+<div class="container mt-4">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h2>Órdenes de Compra</h2>
+    <a class="btn btn-success" href="orden_nueva.html">Nueva Orden</a>
+  </div>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Nº Orden</th>
+        <th>Fecha</th>
+        <th>Proveedor</th>
+        <th>Total</th>
+        <th>Acciones</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>1</td>
+        <td>05/01/2022</td>
+        <td>Proveedor Mayorista</td>
+        <td>$33.00</td>
+        <td>
+          <a class="btn btn-sm btn-primary" href="orden_nueva.html">Ver</a>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/ej4/prototipo/producto_editar.html
+++ b/ej4/prototipo/producto_editar.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tienda Tech - Editar Producto</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">Tienda Tech</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav">
+        <li class="nav-item"><a class="nav-link" href="index.html">Inicio</a></li>
+        <li class="nav-item"><a class="nav-link active" href="productos.html">Productos</a></li>
+        <li class="nav-item"><a class="nav-link" href="producto_nuevo.html">Nuevo Producto</a></li>
+        <li class="nav-item"><a class="nav-link" href="proveedores.html">Proveedores</a></li>
+        <li class="nav-item"><a class="nav-link" href="proveedor_nuevo.html">Nuevo Proveedor</a></li>
+        <li class="nav-item"><a class="nav-link" href="ordenes.html">Órdenes de Compra</a></li>
+        <li class="nav-item"><a class="nav-link" href="orden_nueva.html">Nueva Orden</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+
+<div class="container mt-4">
+  <h2>Editar Producto</h2>
+  <form>
+    <div class="mb-3">
+      <label class="form-label">Nombre</label>
+      <input type="text" class="form-control" value="Notebook X">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Precio</label>
+      <input type="number" class="form-control" value="1500">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Stock</label>
+      <input type="number" class="form-control" value="10">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Descripción</label>
+      <textarea class="form-control" rows="3">Portátil de alto rendimiento.</textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">Actualizar</button>
+    <a class="btn btn-secondary" href="productos.html">Cancelar</a>
+  </form>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/ej4/prototipo/producto_nuevo.html
+++ b/ej4/prototipo/producto_nuevo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tienda Tech - Nuevo Producto</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">Tienda Tech</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav">
+        <li class="nav-item"><a class="nav-link" href="index.html">Inicio</a></li>
+        <li class="nav-item"><a class="nav-link" href="productos.html">Productos</a></li>
+        <li class="nav-item"><a class="nav-link active" href="producto_nuevo.html">Nuevo Producto</a></li>
+        <li class="nav-item"><a class="nav-link" href="proveedores.html">Proveedores</a></li>
+        <li class="nav-item"><a class="nav-link" href="proveedor_nuevo.html">Nuevo Proveedor</a></li>
+        <li class="nav-item"><a class="nav-link" href="ordenes.html">Órdenes de Compra</a></li>
+        <li class="nav-item"><a class="nav-link" href="orden_nueva.html">Nueva Orden</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+
+<div class="container mt-4">
+  <h2>Nuevo Producto</h2>
+  <form>
+    <div class="mb-3">
+      <label class="form-label">Nombre</label>
+      <input type="text" class="form-control" placeholder="Ingrese nombre del producto">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Precio</label>
+      <input type="number" class="form-control" placeholder="Ingrese precio">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Stock</label>
+      <input type="number" class="form-control" placeholder="Ingrese stock disponible">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Descripción</label>
+      <textarea class="form-control" rows="3" placeholder="Detalle del producto"></textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a class="btn btn-secondary" href="productos.html">Cancelar</a>
+  </form>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/ej4/prototipo/productos.html
+++ b/ej4/prototipo/productos.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tienda Tech - Productos</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">Tienda Tech</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav">
+        <li class="nav-item"><a class="nav-link" href="index.html">Inicio</a></li>
+        <li class="nav-item"><a class="nav-link active" href="productos.html">Productos</a></li>
+        <li class="nav-item"><a class="nav-link" href="producto_nuevo.html">Nuevo Producto</a></li>
+        <li class="nav-item"><a class="nav-link" href="proveedores.html">Proveedores</a></li>
+        <li class="nav-item"><a class="nav-link" href="proveedor_nuevo.html">Nuevo Proveedor</a></li>
+        <li class="nav-item"><a class="nav-link" href="ordenes.html">Órdenes de Compra</a></li>
+        <li class="nav-item"><a class="nav-link" href="orden_nueva.html">Nueva Orden</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+
+<div class="container mt-4">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h2>Productos</h2>
+    <a class="btn btn-success" href="producto_nuevo.html">Agregar Producto</a>
+  </div>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Nombre</th>
+        <th>Precio</th>
+        <th>Stock</th>
+        <th>Acciones</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>1</td>
+        <td>Notebook X</td>
+        <td>$1500</td>
+        <td>10</td>
+        <td>
+          <a class="btn btn-sm btn-primary" href="producto_editar.html">Editar</a>
+          <a class="btn btn-sm btn-danger" href="#">Eliminar</a>
+        </td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td>Mouse Gamer</td>
+        <td>$50</td>
+        <td>35</td>
+        <td>
+          <a class="btn btn-sm btn-primary" href="producto_editar.html">Editar</a>
+          <a class="btn btn-sm btn-danger" href="#">Eliminar</a>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/ej4/prototipo/proveedor_editar.html
+++ b/ej4/prototipo/proveedor_editar.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tienda Tech - Editar Proveedor</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">Tienda Tech</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav">
+        <li class="nav-item"><a class="nav-link" href="index.html">Inicio</a></li>
+        <li class="nav-item"><a class="nav-link" href="productos.html">Productos</a></li>
+        <li class="nav-item"><a class="nav-link" href="producto_nuevo.html">Nuevo Producto</a></li>
+        <li class="nav-item"><a class="nav-link active" href="proveedores.html">Proveedores</a></li>
+        <li class="nav-item"><a class="nav-link" href="proveedor_nuevo.html">Nuevo Proveedor</a></li>
+        <li class="nav-item"><a class="nav-link" href="ordenes.html">Órdenes de Compra</a></li>
+        <li class="nav-item"><a class="nav-link" href="orden_nueva.html">Nueva Orden</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+
+<div class="container mt-4">
+  <h2>Editar Proveedor</h2>
+  <form>
+    <div class="mb-3">
+      <label class="form-label">Nombre</label>
+      <input type="text" class="form-control" value="Proveedor Mayorista">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Domicilio</label>
+      <input type="text" class="form-control" value="La Real S.A.">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Ciudad</label>
+      <input type="text" class="form-control" value="Buenos Aires">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Contacto</label>
+      <input type="text" class="form-control" value="Juan">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Teléfono</label>
+      <input type="text" class="form-control" value="333-5212">
+    </div>
+    <button type="submit" class="btn btn-primary">Actualizar</button>
+    <a class="btn btn-secondary" href="proveedores.html">Cancelar</a>
+  </form>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/ej4/prototipo/proveedor_nuevo.html
+++ b/ej4/prototipo/proveedor_nuevo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tienda Tech - Nuevo Proveedor</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">Tienda Tech</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav">
+        <li class="nav-item"><a class="nav-link" href="index.html">Inicio</a></li>
+        <li class="nav-item"><a class="nav-link" href="productos.html">Productos</a></li>
+        <li class="nav-item"><a class="nav-link" href="producto_nuevo.html">Nuevo Producto</a></li>
+        <li class="nav-item"><a class="nav-link" href="proveedores.html">Proveedores</a></li>
+        <li class="nav-item"><a class="nav-link active" href="proveedor_nuevo.html">Nuevo Proveedor</a></li>
+        <li class="nav-item"><a class="nav-link" href="ordenes.html">Órdenes de Compra</a></li>
+        <li class="nav-item"><a class="nav-link" href="orden_nueva.html">Nueva Orden</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+
+<div class="container mt-4">
+  <h2>Nuevo Proveedor</h2>
+  <form>
+    <div class="mb-3">
+      <label class="form-label">Nombre</label>
+      <input type="text" class="form-control" placeholder="Ingrese nombre del proveedor">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Domicilio</label>
+      <input type="text" class="form-control" placeholder="Ingrese domicilio">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Ciudad</label>
+      <input type="text" class="form-control" placeholder="Ingrese ciudad">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Contacto</label>
+      <input type="text" class="form-control" placeholder="Nombre del contacto">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Teléfono</label>
+      <input type="text" class="form-control" placeholder="Ingrese teléfono">
+    </div>
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a class="btn btn-secondary" href="proveedores.html">Cancelar</a>
+  </form>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/ej4/prototipo/proveedores.html
+++ b/ej4/prototipo/proveedores.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tienda Tech - Proveedores</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">Tienda Tech</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav">
+        <li class="nav-item"><a class="nav-link" href="index.html">Inicio</a></li>
+        <li class="nav-item"><a class="nav-link" href="productos.html">Productos</a></li>
+        <li class="nav-item"><a class="nav-link" href="producto_nuevo.html">Nuevo Producto</a></li>
+        <li class="nav-item"><a class="nav-link active" href="proveedores.html">Proveedores</a></li>
+        <li class="nav-item"><a class="nav-link" href="proveedor_nuevo.html">Nuevo Proveedor</a></li>
+        <li class="nav-item"><a class="nav-link" href="ordenes.html">Órdenes de Compra</a></li>
+        <li class="nav-item"><a class="nav-link" href="orden_nueva.html">Nueva Orden</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+
+<div class="container mt-4">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h2>Proveedores</h2>
+    <a class="btn btn-success" href="proveedor_nuevo.html">Agregar Proveedor</a>
+  </div>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Nombre</th>
+        <th>Ciudad</th>
+        <th>Teléfono</th>
+        <th>Acciones</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>1</td>
+        <td>Proveedor Mayorista</td>
+        <td>Buenos Aires</td>
+        <td>123-4567</td>
+        <td>
+          <a class="btn btn-sm btn-primary" href="proveedor_editar.html">Editar</a>
+          <a class="btn btn-sm btn-danger" href="#">Eliminar</a>
+        </td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td>Importadora Tech</td>
+        <td>Córdoba</td>
+        <td>987-6543</td>
+        <td>
+          <a class="btn btn-sm btn-primary" href="proveedor_editar.html">Editar</a>
+          <a class="btn btn-sm btn-danger" href="#">Eliminar</a>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Expand navigation to include supplier and purchase order sections
- Add supplier listing, creation, and editing mock screens
- Add purchase order listing and detailed creation form

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae01b74c18832584d711d96caed1e9